### PR TITLE
build: update package-manager-worker to 0.1.2

### DIFF
--- a/.copr/rhc.spec.in
+++ b/.copr/rhc.spec.in
@@ -16,7 +16,7 @@ URL:     https://github.com/redhatinsights/rhc
 
 Source0: %{name}-%{version}-@RELEASE@.tar.gz
 Source1: https://github.com/RedHatInsights/yggdrasil/releases/download/0.2.2/yggdrasil-0.2.2.tar.gz
-Source2: https://github.com/RedHatInsights/yggdrasil-worker-package-manager/releases/download/0.1.0/yggdrasil-worker-package-manager-0.1.0.tar.gz
+Source2: https://github.com/RedHatInsights/yggdrasil-worker-package-manager/releases/download/0.1.0/yggdrasil-worker-package-manager-0.1.2.tar.gz
 
 ExclusiveArch: %{go_arches}
 
@@ -53,7 +53,7 @@ make PREFIX=%{_prefix} \
      DATAHOST=@DATAHOST@ \
      'PROVIDER=@PROVIDER@'
 
-cd %{_builddir}/%{name}/yggdrasil-worker-package-manager
+cd %{_builddir}/%{name}/yggdrasil-worker-package-manager-0.1.2
 go build -o rhc-package-manager-worker -mod=vendor .
 
 cd %{_builddir}/%{name}/%{name}-%{version}-@RELEASE@
@@ -111,6 +111,7 @@ make PREFIX=%{_prefix} \
 %{_sbindir}/@SHORTNAME@d
 %{_sysconfdir}/@LONGNAME@/
 %config(noreplace) %{_sysconfdir}/@LONGNAME@/config.toml
+%config(noreplace) %{_sysconfdir}/@LONGNAME@/workers/*.toml
 %{_unitdir}/@SHORTNAME@d.service
 %{_datadir}/bash-completion/completions/*
 %{_mandir}/man1/*


### PR DESCRIPTION
The version of the package-manager-worker that was being included in the RPMs produced from this fork was version 0.1.0. That version was missing an important bug fix, https://github.com/RedHatInsights/yggdrasil-worker-package-manager/commit/22105b0016abfc7c743c1eadb0372e4ef93cc65e. That fix has been incorporated into a new yggdrasil-worker-package-manager-0.1.2 tarball. This PR updates the spec file on this fork to use that new tarball.